### PR TITLE
update GitHub project name in setup url

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -108,7 +108,7 @@ NAME = "geonode-announcements"
 DESCRIPTION = "Fork of pinax/django-announcements. Announcements for your Django powered website."
 AUTHOR = "Brian Rosner"
 AUTHOR_EMAIL = "brosner@gmail.com"
-URL = "https://github.com/GeoNode/django-announcements"
+URL = "https://github.com/GeoNode/geonode-announcements"
 VERSION = __import__(PACKAGE).__version__
 
 


### PR DESCRIPTION
s/django-announcements/geonode-announcements/

It's a trivial fix for an error that's gone unnoticed for almost four years on my part at least, but without it the link from PyPI to the repository is broken so I thought I'd bring it to your attention nonetheless. Please feel free to squash or cherry-pick into your next regularly scheduled packaging update... :smile: 

Thanks for sharing your code!