### PR TITLE
Python3 syntax updates: remove __future__ imports, unicode

### DIFF
--- a/announcements/migrations/0001_initial.py
+++ b/announcements/migrations/0001_initial.py
@@ -18,8 +18,6 @@
 #
 #########################################################################
 
-from __future__ import unicode_literals
-
 from django.db import migrations, models
 import django.utils.timezone
 from django.conf import settings

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -4,20 +4,20 @@ extensions = []
 templates_path = []
 source_suffix = '.rst'
 master_doc = 'index'
-project = u'django-announcements'
+project = 'django-announcements'
 package = 'announcements'
 copyright_holder = 'Eldarion'
-copyright = u'2013, %s' % copyright_holder
+copyright = '2013, %s' % copyright_holder
 exclude_patterns = ['_build']
 pygments_style = 'sphinx'
 html_theme = 'default'
 htmlhelp_basename = '%sdoc' % project
 latex_documents = [
-  ('index', '%s.tex' % project, u'%s Documentation' % project,
+  ('index', '%s.tex' % project, '%s Documentation' % project,
    copyright_holder, 'manual'),
 ]
 man_pages = [
-    ('index', project, u'%s Documentation' % project,
+    ('index', project, '%s Documentation' % project,
      [copyright_holder], 1)
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -70,9 +70,7 @@ def find_package_data(
                         or fn.lower() == pattern.lower()):
                         bad_name = True
                         if show_ignored:
-                            print >> sys.stderr, (
-                                "Directory %s ignored by pattern %s"
-                                % (fn, pattern))
+                            print("Directory {0} ignored by pattern {1}".format(fn, pattern), file=sys.stderr)
                         break
                 if bad_name:
                     continue
@@ -93,9 +91,7 @@ def find_package_data(
                         or fn.lower() == pattern.lower()):
                         bad_name = True
                         if show_ignored:
-                            print >> sys.stderr, (
-                                "File %s ignored by pattern %s"
-                                % (fn, pattern))
+                            print("File {0} is ignored by pattern {1}".format(fn, pattern), file=sys.stderr)
                         break
                 if bad_name:
                     continue


### PR DESCRIPTION
Syntax clean up - does not functionally alter anything, but they are ignored by Python 3, so remove them.